### PR TITLE
[TT-1275] Order access to SkTypefaceCache

### DIFF
--- a/src/ports/SkFontMgr_FontConfigInterface.cpp
+++ b/src/ports/SkFontMgr_FontConfigInterface.cpp
@@ -169,8 +169,8 @@ class SkFontMgr_FCI : public SkFontMgr {
 public:
     SkFontMgr_FCI(sk_sp<SkFontConfigInterface> fci)
         : fFCI(std::move(fci))
-        , fCache(kMaxSize)
         , fMutex("SkFontMgr_FCI")
+        , fCache(kMaxSize)
     {}
 
 protected:

--- a/src/ports/SkFontMgr_FontConfigInterface.cpp
+++ b/src/ports/SkFontMgr_FontConfigInterface.cpp
@@ -170,6 +170,7 @@ public:
     SkFontMgr_FCI(sk_sp<SkFontConfigInterface> fci)
         : fFCI(std::move(fci))
         , fCache(kMaxSize)
+        , fMutex("SkFontMgr_FCI")
     {}
 
 protected:

--- a/src/ports/SkFontMgr_fontconfig.cpp
+++ b/src/ports/SkFontMgr_fontconfig.cpp
@@ -721,7 +721,8 @@ public:
     explicit SkFontMgr_fontconfig(FcConfig* config)
         : fFC(config ? config : FcInitLoadConfigAndFonts())
         , fSysroot(reinterpret_cast<const char*>(FcConfigGetSysRoot(fFC)))
-        , fFamilyNames(GetFamilyNames(fFC)) { }
+        , fFamilyNames(GetFamilyNames(fFC))
+        , fTFCacheMutex("SkFontMgr_fontconfig") { }
 
     ~SkFontMgr_fontconfig() override {
         // Hold the lock while unrefing the config.

--- a/src/ports/SkTypeface_mac_ct.cpp
+++ b/src/ports/SkTypeface_mac_ct.cpp
@@ -230,7 +230,7 @@ static bool find_by_CTFontRef(SkTypeface* cached, void* context) {
 sk_sp<SkTypeface> SkTypeface_Mac::Make(SkUniqueCFRef<CTFontRef> font,
                                        OpszVariation opszVariation,
                                        std::unique_ptr<SkStreamAsset> providedData) {
-    static SkMutex gTFCacheMutex;
+    static SkMutex gTFCacheMutex("SkTypeface_Mac::Make");
     static SkTypefaceCache gTFCache;
 
     SkASSERT(font);


### PR DESCRIPTION
* https://github.com/replayio/chromium/pull/1254
* https://linear.app/replay/issue/TT-1275/[sagesure]-mismatch-in-sktypefacecachefindbyprocandref#comment-5263a790