### PR TITLE
WIP: Re-apply Replay skia instrumentation onto M151

### DIFF
--- a/gn/core.gni
+++ b/gn/core.gni
@@ -549,6 +549,8 @@ skia_core_sources = [
   "$_src/core/SkRecordOpts.cpp",
   "$_src/core/SkRecordOpts.h",
   "$_src/core/SkRecordPattern.h",
+  "$_src/core/SkRecordReplay.cpp",
+  "$_src/core/SkRecordReplay.h",
   "$_src/core/SkRecordedDrawable.cpp",
   "$_src/core/SkRecordedDrawable.h",
   "$_src/core/SkRecords.cpp",

--- a/modules/skcms/skcms.cc
+++ b/modules/skcms/skcms.cc
@@ -33,6 +33,33 @@
     #endif
 #endif
 
+#ifndef _WIN32
+#include <dlfcn.h>
+#else
+#include <windows.h>
+#endif
+
+static void* LookupRecordReplaySymbol(const char* name) {
+#ifndef _WIN32
+  void* fnptr = dlsym(RTLD_DEFAULT, name);
+#else
+  HMODULE module = GetModuleHandleA("windows-recordreplay.dll");
+  void* fnptr = module ? (void*)GetProcAddress(module, name) : nullptr;
+#endif
+  return fnptr ? fnptr : reinterpret_cast<void*>(1);
+}
+
+static bool RecordReplayIsReplaying() {
+  static void* fnptr;
+  if (!fnptr) {
+    fnptr = LookupRecordReplaySymbol("RecordReplayIsReplaying");
+  }
+  if (fnptr != reinterpret_cast<void*>(1)) {
+    return reinterpret_cast<bool(*)()>(fnptr)();
+  }
+  return false;
+}
+
 using namespace skcms_private;
 
 // A potential vulnerability exists where a large CLUT can cause an integer
@@ -2486,6 +2513,14 @@ static CpuType cpu_type() {
             if (!sAllowRuntimeCPUDetection) {
                 return CpuType::Baseline;
             }
+
+                // When replaying, memory snapshots might be taken and restored on a
+                // machine with different CPU characteristics, invalidating the cached
+                // CPU type.
+                if (RecordReplayIsReplaying()) {
+                    return CpuType::None;
+                }
+
             // See http://www.sandpile.org/x86/cpuid.htm
 
             // First, a basic cpuid(1) lets us check prerequisites for HSW, SKX.

--- a/src/core/SkBitmap.cpp
+++ b/src/core/SkBitmap.cpp
@@ -35,6 +35,8 @@
 #include <utility>
 class SkMaskFilter;
 
+#include "src/core/SkRecordReplay.h"
+
 static bool reset_return_false(SkBitmap* bm) {
     bm->reset();
     return false;
@@ -317,6 +319,9 @@ bool SkBitmap::installPixels(const SkImageInfo& requestedInfo, void* pixels, siz
         this->reset();
         return false;
     }
+    SkRecordReplayAssert("[RUN-593-1824] SkBitmap::installPixels A %d %d",
+                         nullptr == pixels,
+                         nullptr == releaseProc);
     if (nullptr == pixels) {
         invoke_release_proc(releaseProc, pixels, context);
         return true;    // we behaved as if they called setInfo()

--- a/src/core/SkCachedData.cpp
+++ b/src/core/SkCachedData.cpp
@@ -9,8 +9,11 @@
 #include "include/private/base/SkMalloc.h"
 #include "include/private/chromium/SkDiscardableMemory.h"
 
+#include "src/core/SkRecordReplay.h"
+
 SkCachedData::SkCachedData(void* data, size_t size)
-    : fData(data)
+    : fMutex("SkCachedData.fMutex")
+    , fData(data)
     , fSize(size)
     , fRefCnt(1)
     , fStorageType(kMalloc_StorageType)
@@ -21,7 +24,8 @@ SkCachedData::SkCachedData(void* data, size_t size)
 }
 
 SkCachedData::SkCachedData(size_t size, SkDiscardableMemory* dm)
-    : fData(dm->data())
+    : fMutex("SkCachedData.fMutex")
+    , fData(dm->data())
     , fSize(size)
     , fRefCnt(1)
     , fStorageType(kDiscardableMemory_StorageType)
@@ -74,6 +78,8 @@ void SkCachedData::internalUnref(bool fromCache) const {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 void SkCachedData::inMutexRef(bool fromCache) {
+    SkRecordReplayAssert(
+            "[RUN-2367-2368] SkCachedData::inMutexRef %d %d %d", fRefCnt, fInCache, fromCache);
     if ((1 == fRefCnt) && fInCache) {
         this->inMutexLock();
     }
@@ -86,6 +92,8 @@ void SkCachedData::inMutexRef(bool fromCache) {
 }
 
 bool SkCachedData::inMutexUnref(bool fromCache) {
+    SkRecordReplayAssert(
+            "[RUN-2367-2368] SkCachedData::inMutexUnref %d %d %d", fRefCnt, fInCache, fromCache);
     switch (--fRefCnt) {
         case 0:
             // we're going to be deleted, so we need to be unlocked (for DiscardableMemory)
@@ -119,6 +127,8 @@ void SkCachedData::inMutexLock() {
 
     SkASSERT(!fIsLocked);
     fIsLocked = true;
+
+    SkRecordReplayAssert("[RUN-2367-2368] SkCachedData::inMutexLock %d", (int)fStorageType);
 
     switch (fStorageType) {
         case kMalloc_StorageType:

--- a/src/core/SkClipStack.cpp
+++ b/src/core/SkClipStack.cpp
@@ -902,6 +902,7 @@ uint32_t SkClipStack::GetNextGenID() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id < kFirstUnreservedGenID);
+    SkRecordReplayAssert("[RUN-593-1969] SkClipStack::GetNextGenID %u", id);
     return id;
 }
 

--- a/src/core/SkCpu.cpp
+++ b/src/core/SkCpu.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "src/core/SkCpu.h"
+#include "src/core/SkRecordReplay.h"
 
 #include "include/private/base/SkFeatures.h"
 #include "include/private/base/SkOnce.h"
@@ -232,5 +233,10 @@ uint32_t SkCpu::gCachedFeatures = 0;
 
 void SkCpu::CacheRuntimeFeatures() {
     static SkOnce once;
-    once([] { gCachedFeatures = read_cpu_features(); });
+    once([]{
+        if (SkRecordReplayIsReplaying()) {
+            return;
+        }
+        gCachedFeatures = read_cpu_features();
+    });
 }

--- a/src/core/SkDescriptor.cpp
+++ b/src/core/SkDescriptor.cpp
@@ -17,6 +17,8 @@
 
 #include <cstring>
 
+#include "src/core/SkRecordReplay.h"
+
 std::unique_ptr<SkDescriptor> SkDescriptor::Alloc(size_t length) {
     SkASSERT(length >= sizeof(SkDescriptor) && SkIsAlign4(length));
     void* allocation = ::operator new(length);
@@ -36,6 +38,10 @@ void* SkDescriptor::addEntry(uint32_t tag, size_t length, const void* data) {
     SkASSERT(tag);
     SkASSERT(SkIsAlign4(length));
     SkASSERT(this->findEntry(tag, nullptr) == nullptr);
+
+    // https://linear.app/replay/issue/RUN-845
+    SkRecordReplayAssert("[RUN-845] SkDescriptor::addEntry %u %zu %u",
+                         tag, length, (data && length) ? SkOpts::hash(data, length) : 0);
 
     Entry* entry = (Entry*)((char*)this + fLength);
     entry->fTag = tag;

--- a/src/core/SkDrawable.cpp
+++ b/src/core/SkDrawable.cpp
@@ -19,6 +19,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "src/core/SkRecordReplay.h"
+
 static int32_t next_generation_id() {
     static std::atomic<int32_t> nextID{1};
 
@@ -26,6 +28,7 @@ static int32_t next_generation_id() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == 0);
+    SkRecordReplayAssert("[RUN-593-1969] next_generation_id %d", id);
     return id;
 }
 

--- a/src/core/SkFont.cpp
+++ b/src/core/SkFont.cpp
@@ -40,6 +40,8 @@
 
 using namespace skia_private;
 
+#include "src/core/SkRecordReplay.h"
+
 #define kDefault_Size       SkPaintDefaults_TextSize
 #define kDefault_Flags      SkFont::kBaselineSnap_PrivFlag
 #define kDefault_Edging     SkFont::Edging::kAntiAlias
@@ -246,6 +248,14 @@ void SkFont::getWidthsBounds(SkSpan<const SkGlyphID> glyphIDs,
                              SkSpan<SkScalar> widths,
                              SkSpan<SkRect> bounds,
                              const SkPaint* paint) const {
+    // https://linear.app/replay/issue/RUN-480
+    SkRecordReplayAssert("SkFont::getWidthsBounds %d", count);
+
+    for (int i = 0; i < count; i++) {
+      // https://linear.app/replay/issue/RUN-480
+      SkRecordReplayAssert("SkFont::getWidthsBounds #1 %d %d", i, glyphIDs[i]);
+    }
+
     auto [strikeSpec, strikeToSourceScale] = SkStrikeSpec::MakeCanonicalized(*this, paint);
     SkBulkGlyphMetrics metrics{strikeSpec};
     SkSpan<const SkGlyph*> glyphs = metrics.glyphs(glyphIDs);

--- a/src/core/SkImageFilter.cpp
+++ b/src/core/SkImageFilter.cpp
@@ -142,6 +142,7 @@ static int32_t next_image_filter_unique_id() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == 0);
+    id = SkRecordReplayValue("next_image_filter_unique_id", id);
     return id;
 }
 

--- a/src/core/SkMessageBus.h
+++ b/src/core/SkMessageBus.h
@@ -17,6 +17,8 @@
 #include "include/private/base/SkTArray.h"
 #include "include/private/base/SkTDArray.h"
 
+#include "src/core/SkRecordReplay.h"
+
 /**
  * The following method must have a specialization for type 'Message':
  *
@@ -82,10 +84,15 @@ private:
 
 template <typename Message, typename IDType, bool AllowCopyableMessage>
 SkMessageBus<Message, IDType, AllowCopyableMessage>::Inbox::Inbox(IDType uniqueID)
-        : fUniqueID(uniqueID) {
+        : fMessagesMutex("SkMessageBus::Inbox.fMessagesMutex"),
+          fUniqueID(uniqueID) {
     // Register ourselves with the corresponding message bus.
     auto* bus = SkMessageBus<Message, IDType, AllowCopyableMessage>::Get();
     SkAutoMutexExclusive lock(bus->fInboxesMutex);
+
+    SkRecordReplayAssert(
+        "[RUN-593-1883] SkMessageBus::Inbox::Inbox %d", (int)bus->fInboxes.size());
+
     bus->fInboxes.push_back(this);
 }
 
@@ -97,15 +104,20 @@ SkMessageBus<Message, IDType, AllowCopyableMessage>::Inbox::~Inbox() {
     // This is a cheaper fInboxes.remove(fInboxes.find(this)) when order doesn't matter.
     for (int i = 0; i < bus->fInboxes.size(); i++) {
         if (this == bus->fInboxes[i]) {
+            SkRecordReplayAssert("[RUN-593-1883] SkMessageBus::Inbox::~Inbox A %d %d", i,
+                                 (int)bus->fInboxes.size());
             bus->fInboxes.removeShuffle(i);
             break;
         }
     }
+    SkRecordReplayAssert(
+            "[RUN-593-1883] SkMessageBus::Inbox::~Inbox B %d", (int)bus->fInboxes.size());
 }
 
 template <typename Message, typename IDType, bool AllowCopyableMessage>
 void SkMessageBus<Message, IDType, AllowCopyableMessage>::Inbox::receive(Message m) {
     SkAutoMutexExclusive lock(fMessagesMutex);
+    SkRecordReplayAssert("[RUN-593-1863] SkMessageBus::Inbox::receive %d", (int)fMessages.size());
     fMessages.push_back(std::move(m));
 }
 
@@ -115,19 +127,26 @@ void SkMessageBus<Message, IDType, AllowCopyableMessage>::Inbox::poll(
     SkASSERT(messages);
     messages->clear();
     SkAutoMutexExclusive lock(fMessagesMutex);
+    SkRecordReplayAssert("[RUN-593-1863] SkMessageBus::Inbox::poll %d %d",
+                         (int)fMessages.size(),
+                         (int)messages->size());
     fMessages.swap(*messages);
 }
 
 //   ----------------------- Implementation of SkMessageBus -----------------------
 
 template <typename Message, typename IDType, bool AllowCopyableMessage>
-SkMessageBus<Message, IDType, AllowCopyableMessage>::SkMessageBus() = default;
+SkMessageBus<Message, IDType, AllowCopyableMessage>::SkMessageBus()
+  : fInboxesMutex("SkMessageBus.fInboxesMutex") {}
 
 template <typename Message, typename IDType, bool AllowCopyableMessage>
 /*static*/ void SkMessageBus<Message, IDType, AllowCopyableMessage>::Post(Message m) {
     auto* bus = SkMessageBus<Message, IDType, AllowCopyableMessage>::Get();
     SkAutoMutexExclusive lock(bus->fInboxesMutex);
     for (int i = 0; i < bus->fInboxes.size(); i++) {
+        SkRecordReplayAssert("[RUN-593-1801] SkMessageBus::Post %d %d",
+                             i,
+                             (int)bus->fInboxes.size());
         if (SkShouldPostMessageToBus(m, bus->fInboxes[i]->fUniqueID)) {
             if constexpr (AllowCopyableMessage) {
                 bus->fInboxes[i]->receive(m);

--- a/src/core/SkPicture.cpp
+++ b/src/core/SkPicture.cpp
@@ -47,11 +47,18 @@ SkPicture::SkPicture() {
     do {
         fUniqueID = nextID.fetch_add(+1, std::memory_order_relaxed);
     } while (fUniqueID == 0);
+
+    SkRecordReplayAssert("[RUN-593-1863] SkPicture::fUniqueID %u", fUniqueID);
 }
 
 SkPicture::~SkPicture() {
     if (fAddedToCache.load()) {
-        SkResourceCache::PostPurgeSharedID(SkPicturePriv::MakeSharedID(fUniqueID));
+        if (!SkRecordReplayIsRecordingOrReplaying(/* "leak-references" */) || !SkRecordReplayAreEventsDisallowed()) {
+            SkResourceCache::PostPurgeSharedID(SkPicturePriv::MakeSharedID(fUniqueID));
+        } else {
+            // Leak and print (so we get a general idea of memory impact)
+            SkRecordReplayPrint("[RUN-593-1863] SkPicture::~SkPicture - [LEAK] SkPicture %u", fUniqueID);
+        }
     }
 }
 

--- a/src/core/SkPixelRef.cpp
+++ b/src/core/SkPixelRef.cpp
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <utility>
 
+#include "src/core/SkRecordReplay.h"
+
 uint32_t SkNextID::ImageID() {
     // We never set the low bit.... see SkPixelRef::genIDIsUnique().
     static std::atomic<uint32_t> nextID{2};
@@ -25,6 +27,9 @@ uint32_t SkNextID::ImageID() {
     do {
         id = nextID.fetch_add(2, std::memory_order_relaxed);
     } while (id == 0);
+
+    id = SkRecordReplayValue("SkNextID::ImageID", id);
+
     return id;
 }
 
@@ -77,6 +82,9 @@ uint32_t SkPixelRef::getGenerationID() const {
         // We can't quite SkASSERT(this->genIDIsUnique()). It could be non-unique
         // if we got here via the else path (pretty unlikely, but possible).
     }
+
+    SkRecordReplayAssert("[RUN-593-1863] SkPixelRef::getGenerationID %u", id);
+
     return id & ~1u;  // Mask off bottom unique bit.
 }
 
@@ -93,9 +101,20 @@ void SkPixelRef::addGenIDChangeListener(sk_sp<SkIDChangeListener> listener) {
 void SkPixelRef::callGenIDChangeListeners() {
     // We don't invalidate ourselves if we think another SkPixelRef is sharing our genID.
     if (this->genIDIsUnique()) {
+        if (!SkRecordReplayAreEventsDisallowed())
+            SkRecordReplayAssert("[RUN-593-1824] SkPixelRef::callGenIDChangeListeners");
+
         fGenIDChangeListeners.changed();
         if (fAddedToCache.exchange(false)) {
-            SkNotifyBitmapGenIDIsStale(this->getGenerationID());
+            if (!SkRecordReplayIsRecordingOrReplaying(/* "leak-references" */) ||
+                !SkRecordReplayAreEventsDisallowed()) {
+                SkNotifyBitmapGenIDIsStale(this->getGenerationID());
+            } else {
+                // Leak and print (so we get a general idea of memory impact)
+                SkRecordReplayPrint(
+                        "[RUN-593-1883] SkPixelRef::callGenIDChangeListeners - [LEAK] SkPixelRef %u",
+                        this->getGenerationID());
+            }
         }
     } else {
         // Listeners get at most one shot, so even though these weren't triggered or not, blow them

--- a/src/core/SkPixmap.cpp
+++ b/src/core/SkPixmap.cpp
@@ -29,6 +29,8 @@
 #include <iterator>
 #include <utility>
 
+#include "src/core/SkRecordReplay.h"
+
 void SkPixmap::reset() {
     fPixels = nullptr;
     fRowBytes = 0;
@@ -198,6 +200,11 @@ SkColor SkPixmap::getColor(int x, int y) const {
         return needsUnpremul ? SkUnPreMultiply::PMColorToColor(maybePremulColor)
                              : SkSwizzle_BGRA_to_PMColor(maybePremulColor);
     };
+
+    SkRecordReplayAssert(
+            "[RUN-593-1824] SkPixmap::scalePixels %d %d",
+            src.width() <= 0 || src.height() <= 0 || dst.width() <= 0 || dst.height() <= 0,
+            src.width() == dst.width() && src.height() == dst.height());
 
     switch (this->colorType()) {
         case kGray_8_SkColorType: {

--- a/src/core/SkRecordReplay.cpp
+++ b/src/core/SkRecordReplay.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "include/private/SkOnce.h"
+#include "SkRecordReplay.h"
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#else
+#include <windows.h>
+#endif
+
+#include <stdarg.h>
+#include <string.h>
+
+#include <string>
+
+
+// ##########################################################################
+// Driver/Linker API
+// ##########################################################################
+static bool gRecordingOrReplaying;
+static bool gHasDisabledFeatures;
+
+static void (*gRecordReplayPrint)(const char* format, va_list args);
+static void (*gRecordReplayWarning)(const char* format, va_list args);
+static void (*gRecordReplayAssert)(const char*, va_list);
+static void (*gRecordReplayDiagnostic)(const char*, va_list);
+static void (*gRecordReplayRegisterPointer)(const void* ptr);
+static void (*gRecordReplayUnregisterPointer)(const void* ptr);
+static int (*gRecordReplayPointerId)(const void* ptr);
+
+static bool (*gRecordReplayHasDisabledFeatures)();
+static bool (*gRecordReplayFeatureEnabled)(const char* feature, const char* subfeature);
+static bool (*gRecordReplayAreEventsDisallowed)();
+static void (*gRecordReplayBeginPassThroughEvents)();
+static void (*gRecordReplayEndPassThroughEvents)();
+static bool (*gRecordReplayIsReplaying)(void);
+static bool (*gRecordReplayHasDivergedFromRecording)(void);
+static uintptr_t (*gRecordReplayValue)(const char* why, uintptr_t v);
+
+template <typename Src, typename Dst>
+static inline void CastPointer(const Src src, Dst* dst) {
+  static_assert(sizeof(Src) == sizeof(void*), "bad size");
+  static_assert(sizeof(Dst) == sizeof(void*), "bad size");
+  memcpy((void*)dst, (const void*)&src, sizeof(void*));
+}
+
+template <typename T>
+static void RecordReplayLoadSymbol(const char* name, T& function) {
+#ifndef _WIN32
+  void* sym = dlsym(RTLD_DEFAULT, name);
+#else
+  HMODULE module = GetModuleHandleA("windows-recordreplay.dll");
+  void* sym = module ? (void*)GetProcAddress(module, name) : nullptr;
+#endif
+  if (sym) {
+    CastPointer(sym, &function);
+  }
+}
+
+static inline bool EnsureInitialized() {
+  static SkOnce once;
+  once([]{
+    RecordReplayLoadSymbol("RecordReplayPrint", gRecordReplayPrint);
+    RecordReplayLoadSymbol("RecordReplayWarning", gRecordReplayWarning);
+    RecordReplayLoadSymbol("RecordReplayAssert", gRecordReplayAssert);
+    RecordReplayLoadSymbol("RecordReplayDiagnostic", gRecordReplayDiagnostic);
+    RecordReplayLoadSymbol("RecordReplayRegisterPointer", gRecordReplayRegisterPointer);
+    RecordReplayLoadSymbol("RecordReplayUnregisterPointer", gRecordReplayUnregisterPointer);
+    RecordReplayLoadSymbol("RecordReplayPointerId", gRecordReplayPointerId);
+
+    RecordReplayLoadSymbol("RecordReplayHasDisabledFeatures", gRecordReplayHasDisabledFeatures);
+    RecordReplayLoadSymbol("RecordReplayFeatureEnabled", gRecordReplayFeatureEnabled);
+    RecordReplayLoadSymbol("RecordReplayAreEventsDisallowed", gRecordReplayAreEventsDisallowed);
+    RecordReplayLoadSymbol("RecordReplayBeginPassThroughEvents", gRecordReplayBeginPassThroughEvents);
+    RecordReplayLoadSymbol("RecordReplayEndPassThroughEvents", gRecordReplayEndPassThroughEvents);
+    RecordReplayLoadSymbol("RecordReplayIsReplaying", gRecordReplayIsReplaying);
+    RecordReplayLoadSymbol("RecordReplayHasDivergedFromRecording", gRecordReplayHasDivergedFromRecording);
+    RecordReplayLoadSymbol("RecordReplayValue", gRecordReplayValue);
+
+    gRecordingOrReplaying =
+            gRecordReplayFeatureEnabled && gRecordReplayFeatureEnabled("record-replay", nullptr);
+    gHasDisabledFeatures = gRecordingOrReplaying && gRecordReplayHasDisabledFeatures();
+  });
+  return !!gRecordReplayAssert;
+}
+
+void SkRecordReplayPrint(const char* format, ...) {
+  if (SkRecordReplayIsRecordingOrReplaying()) {
+    va_list args;
+    va_start(args, format);
+    gRecordReplayPrint(format, args);
+    va_end(args);
+  }
+}
+
+void SkRecordReplayWarning(const char* format, ...) {
+  if (EnsureInitialized()) {
+    va_list ap;
+    va_start(ap, format);
+    gRecordReplayWarning(format, ap);
+    va_end(ap);
+  }
+}
+
+void SkRecordReplayAssert(const char* format, ...) {
+  if (EnsureInitialized()) {
+    va_list ap;
+    va_start(ap, format);
+    gRecordReplayAssert(format, ap);
+    va_end(ap);
+  }
+}
+
+void SkRecordReplayDiagnostic(const char* format, ...) {
+  if (EnsureInitialized()) {
+    va_list ap;
+    va_start(ap, format);
+    gRecordReplayDiagnostic(format, ap);
+    va_end(ap);
+  }
+}
+
+void SkRecordReplayRegisterPointer(const void* ptr) {
+  if (EnsureInitialized()) {
+    gRecordReplayRegisterPointer(ptr);
+  }
+}
+
+void SkRecordReplayUnregisterPointer(const void* ptr) {
+  if (EnsureInitialized()) {
+    gRecordReplayUnregisterPointer(ptr);
+  }
+}
+
+bool SkRecordReplayFeatureEnabled(const char* feature, const char* subfeature) {
+  if (EnsureInitialized()) {
+    if (!gHasDisabledFeatures) {
+        return true;
+    }
+    return gRecordReplayFeatureEnabled(feature, subfeature);
+  }
+  return true;
+}
+
+bool SkRecordReplayIsRecordingOrReplaying(const char* feature, const char* subfeature) {
+  return EnsureInitialized() && gRecordingOrReplaying &&
+    (!feature || SkRecordReplayFeatureEnabled(feature, subfeature));
+}
+
+bool SkRecordReplayAreEventsDisallowed(const char* why) {
+  if (EnsureInitialized()) {
+    if (SkRecordReplayIsRecordingOrReplaying("disallow-events", why)) {
+      return gRecordReplayAreEventsDisallowed();
+    }
+  }
+  return false;
+}
+
+void SkRecordReplayBeginPassThroughEvents() {
+  if (EnsureInitialized()) {
+    gRecordReplayBeginPassThroughEvents();
+  }
+}
+
+void SkRecordReplayEndPassThroughEvents() {
+  if (EnsureInitialized()) {
+    gRecordReplayEndPassThroughEvents();
+  }
+}
+
+bool SkRecordReplayIsReplaying(void) {
+  return EnsureInitialized() && gRecordReplayIsReplaying();
+}
+
+bool SkRecordReplayHasDivergedFromRecording(void) {
+  return EnsureInitialized() && 
+    gRecordReplayIsReplaying() && 
+    gRecordReplayHasDivergedFromRecording();
+}
+
+bool SkRecordReplayAreEventsUnavailable(const char* why) {
+  return SkRecordReplayAreEventsDisallowed(why) ||
+    SkRecordReplayHasDivergedFromRecording();
+}
+
+uintptr_t SkRecordReplayValue(const char* why, uintptr_t v) {
+  if (SkRecordReplayIsRecordingOrReplaying("values", why)) {
+    return gRecordReplayValue(why, v);
+  }
+  return v;
+}

--- a/src/core/SkRecordReplay.h
+++ b/src/core/SkRecordReplay.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2006 The Android Open Source Project
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef SkRecordReplay_DEFINED
+#define SkRecordReplay_DEFINED
+
+extern void SkRecordReplayPrint(const char* format, ...);
+extern void SkRecordReplayWarning(const char* format, ...);
+extern void SkRecordReplayAssert(const char* format, ...);
+extern void SkRecordReplayDiagnostic(const char* format, ...);
+extern void SkRecordReplayRegisterPointer(const void* ptr);
+extern void SkRecordReplayUnregisterPointer(const void* ptr);
+extern int SkRecordReplayPointerId(const void* ptr);
+
+extern bool SkRecordReplayFeatureEnabled(const char* feature, const char* subfeature);
+extern bool SkRecordReplayIsRecordingOrReplaying(const char* feature = nullptr,
+                                                 const char* subfeature = nullptr);
+extern bool SkRecordReplayAreEventsDisallowed(const char* why = nullptr);
+extern void SkRecordReplayBeginPassThroughEvents();
+extern void SkRecordReplayEndPassThroughEvents();
+extern bool SkRecordReplayIsReplaying();
+extern bool SkRecordReplayHasDivergedFromRecording();
+extern bool SkRecordReplayAreEventsUnavailable(const char* why);
+extern uintptr_t SkRecordReplayValue(const char* why, uintptr_t v);
+
+#endif

--- a/src/core/SkResourceCache.cpp
+++ b/src/core/SkResourceCache.cpp
@@ -127,7 +127,9 @@ SkResourceCache::~SkResourceCache() {
 bool SkResourceCache::find(const Key& key, FindVisitor visitor, void* context) {
     this->checkMessages();
 
-    if (auto found = fHash->find(key)) {
+    auto found = fHash->find(key);
+    SkRecordReplayAssert("[RUN-593] SkResourceCache::find %d", !!found);
+    if (found) {
         Rec* rec = *found;
         if (visitor(*rec, context)) {
             this->moveToHead(rec);  // for our LRU
@@ -174,6 +176,10 @@ void SkResourceCache::add(Rec* rec, void* payload) {
     fHash->set(rec);
     rec->postAddInstall(payload);
 
+    // https://linear.app/replay/issue/RUN-593
+    SkRecordReplayAssert(
+        "[RUN-593] SkResourceCache::add %llu %s", rec->bytesUsed(), rec->getCategory());
+
     if (gDumpCacheTransactions) {
         SkString bytesStr, totalStr;
         make_size_str(rec->bytesUsed(), &bytesStr);
@@ -190,6 +196,10 @@ void SkResourceCache::remove(Rec* rec) {
     SkASSERT(rec->canBePurged());
     size_t used = rec->bytesUsed();
     SkASSERT(used <= fTotalBytesUsed);
+
+    // https://linear.app/replay/issue/RUN-593
+    SkRecordReplayAssert(
+            "[RUN-593] SkResourceCache::remove %d %s", rec->bytesUsed(), rec->getCategory());
 
     this->release(rec);
     fHash->remove(rec->getKey());
@@ -244,6 +254,7 @@ static int gPurgeHitCounter;
 #endif
 
 void SkResourceCache::purgeSharedID(uint64_t sharedID) {
+    SkRecordReplayAssert("[RUN-593-1783] SkResourceCache::purgeSharedID A %llu", sharedID);
     if (0 == sharedID) {
         return;
     }
@@ -257,6 +268,10 @@ void SkResourceCache::purgeSharedID(uint64_t sharedID) {
     Rec* rec = fTail;
     while (rec) {
         Rec* prev = rec->fPrev;
+        SkRecordReplayAssert("[RUN-593-1783] SkResourceCache::purgeSharedID B %llu %d %d",
+                             sharedID,
+                             rec->getKey().getSharedID() == sharedID,
+                             rec->canBePurged());
         if (rec->getKey().getSharedID() == sharedID) {
             // even though the "src" is now dead, caches could still be in-flight, so
             // we have to check if it can be removed.
@@ -269,6 +284,8 @@ void SkResourceCache::purgeSharedID(uint64_t sharedID) {
         }
         rec = prev;
     }
+
+    SkRecordReplayAssert("[RUN-593-1783] SkResourceCache::purgeSharedID C %llu", sharedID);
 
 #ifdef SK_TRACK_PURGE_SHAREDID_HITRATE
     if (found) {
@@ -454,6 +471,8 @@ size_t SkResourceCache::getEffectiveSingleAllocationByteLimit() const {
 void SkResourceCache::checkMessages() {
     TArray<PurgeSharedIDMessage> msgs;
     fPurgeSharedIDInbox.poll(&msgs);
+
+    SkRecordReplayAssert("[RUN-593-1783] SkResourceCache::checkMessages %d", msgs.count());
     for (int i = 0; i < msgs.size(); ++i) {
         this->purgeSharedID(msgs[i].fSharedID);
     }
@@ -519,7 +538,8 @@ void SkResourceCache::CheckMessages() {
 }
 
 bool SkResourceCache::Find(const Key& key, FindVisitor visitor, void* context) {
-    return get_cache()->find(key, visitor, context);
+    bool rv = get_cache()->find(key, visitor, context);
+    return rv;
 }
 
 void SkResourceCache::Add(Rec* rec, void* payload) {
@@ -532,6 +552,10 @@ void SkResourceCache::VisitAll(Visitor visitor, void* context) {
 
 void SkResourceCache::PostPurgeSharedID(uint64_t sharedID) {
     if (sharedID) {
+        // Allow purging shared IDs during GC.
+        if (SkRecordReplayAreEventsDisallowed())
+            SkRecordReplayBeginPassThroughEvents();
+
         SkMessageBus<PurgeSharedIDMessage, uint32_t>::Post(PurgeSharedIDMessage(sharedID));
     }
 }

--- a/src/core/SkScalerContext.cpp
+++ b/src/core/SkScalerContext.cpp
@@ -49,6 +49,8 @@
 #include <new>
 #include <utility>
 
+#include "src/core/SkRecordReplay.h"
+
 ///////////////////////////////////////////////////////////////////////////////
 
 namespace {
@@ -1251,6 +1253,16 @@ static size_t calculate_size_and_flatten(const SkScalerContextRec& rec,
 static void generate_descriptor(const SkScalerContextRec& rec,
                                 const SkBinaryWriteBuffer& effectBuffer,
                                 SkDescriptor* desc) {
+    // https://linear.app/replay/issue/RUN-845
+    SkRecordReplayAssert("[RUN-845] generate_descriptor %u %.2f %.2f %.2f Post2x2 %.2f %.2f %.2f %.2f %.2f %.2f Foreground %u %u %.2f %.2f %.2f",
+                         rec.fTypefaceID, rec.fTextSize, rec.fPreScaleX, rec.fPreSkewX,
+                         rec.fPost2x2[0][0], rec.fPost2x2[0][1], rec.fPost2x2[1][0], rec.fPost2x2[1][1], rec.fFrameWidth, rec.fMiterLimit,
+                         rec.fForegroundColor,
+                         rec.getLuminanceColor(),
+                         rec.getDeviceGamma(),
+                         rec.getPaintGamma(),
+                         rec.getContrast());
+
     desc->addEntry(kRec_SkDescriptorTag, sizeof(rec), &rec);
 
     if (effectBuffer.bytesWritten() > 0) {

--- a/src/core/SkStrikeCache.cpp
+++ b/src/core/SkStrikeCache.cpp
@@ -25,6 +25,8 @@ struct SkFontMetrics;
 
 using namespace sktext;
 
+#include "src/core/SkRecordReplay.h"
+
 bool gSkUseThreadLocalStrikeCaches_IAcknowledgeThisIsIncrediblyExperimental = false;
 
 SkStrikeCache* SkStrikeCache::GlobalStrikeCache() {
@@ -39,6 +41,10 @@ SkStrikeCache* SkStrikeCache::GlobalStrikeCache() {
 auto SkStrikeCache::findOrCreateStrike(const SkStrikeSpec& strikeSpec) -> sk_sp<SkStrike> {
     SkAutoMutexExclusive ac(fLock);
     sk_sp<SkStrike> strike = this->internalFindStrikeOrNull(strikeSpec.descriptor());
+
+    // https://linear.app/replay/issue/RUN-845
+    SkRecordReplayAssert("SkStrikeCache::findOrCreateStrike #1 %u %d", strikeSpec.descriptor().getChecksum(), !!strike);
+
     if (strike == nullptr) {
         strike = this->internalCreateStrike(strikeSpec);
     }

--- a/src/core/SkStrikeCache.h
+++ b/src/core/SkStrikeCache.h
@@ -40,7 +40,7 @@ struct SkFontMetrics;
 
 class SkStrikeCache final : public sktext::StrikeForGPUCacheInterface {
 public:
-    SkStrikeCache() = default;
+    SkStrikeCache() : fLock("SkStrikeCache.fLock") {}
 
     static SkStrikeCache* GlobalStrikeCache();
 

--- a/src/core/SkTextBlob.cpp
+++ b/src/core/SkTextBlob.cpp
@@ -148,6 +148,7 @@ static uint32_t next_id() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidGenID);
+    SkRecordReplayAssert("[RUN-593-1969] SkTextBlob/next_id %d", id);
     return id;
 }
 
@@ -925,6 +926,9 @@ int get_glyph_run_intercepts(const sktext::GlyphRun& glyphRun,
 
 int SkTextBlob::getIntercepts(const SkScalar bounds[2], SkScalar intervals[],
                               const SkPaint* paint) const {
+    SkRecordReplayAssert("[RUN-757] SkTextBlob::getIntercepts Start %.2f %.2f",
+                         bounds[0], bounds[1]);
+
     std::optional<SkPaint> defaultPaint;
     if (paint == nullptr) {
         defaultPaint.emplace();
@@ -942,6 +946,8 @@ int SkTextBlob::getIntercepts(const SkScalar bounds[2], SkScalar intervals[],
                 glyphRun, *paint, bounds, intervals, &intervalCount);
         }
     }
+
+    SkRecordReplayAssert("[RUN-757] SkTextBlob::getIntercepts Done");
 
     return intervalCount;
 }

--- a/src/core/SkTypeface.cpp
+++ b/src/core/SkTypeface.cpp
@@ -54,8 +54,13 @@
 
 using namespace skia_private;
 
+#include "src/core/SkRecordReplay.h"
+
 SkTypeface::SkTypeface(const SkFontStyle& style, bool isFixedPitch)
-    : fUniqueID(SkTypefaceCache::NewTypefaceID()), fStyle(style), fIsFixedPitch(isFixedPitch) { }
+    : fUniqueID(SkTypefaceCache::NewTypefaceID()), fStyle(style), fIsFixedPitch(isFixedPitch)
+{
+    SkRecordReplayAssert("[RUN-593-1969] SkTypeface::SkTypeface %u", fUniqueID);
+}
 
 SkTypeface::~SkTypeface() { }
 

--- a/src/core/SkTypefaceCache.cpp
+++ b/src/core/SkTypefaceCache.cpp
@@ -7,6 +7,8 @@
 
 #include "src/core/SkTypefaceCache.h"
 
+#include "src/core/SkRecordReplay.h"
+
 #include "include/core/SkFontStyle.h"
 #include "include/core/SkGraphics.h"
 #include "include/core/SkString.h"
@@ -31,6 +33,8 @@ void SkTypefaceCache::add(sk_sp<SkTypeface> face) {
         fTypefaces.emplace_back(std::move(face));
     }
 }
+
+    SkRecordReplayAssert("[RUN-2612-2639] SkTypefaceCache::add %u", face->uniqueID());
 
 sk_sp<SkTypeface> SkTypefaceCache::findByProcAndRef(FindProc proc, void* ctx) const {
     for (const sk_sp<SkTypeface>& typeface : fTypefaces) {

--- a/src/core/SkVertices.cpp
+++ b/src/core/SkVertices.cpp
@@ -18,6 +18,8 @@
 #include "src/core/SkVerticesPriv.h"
 #include "src/core/SkWriteBuffer.h"
 
+#include "src/core/SkRecordReplay.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
@@ -31,6 +33,7 @@ static uint32_t next_id() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidGenID);
+    SkRecordReplayAssert("[RUN-593-1969] SkVertices/next_id %d", id);
     return id;
 }
 

--- a/src/gpu/ResourceKey.cpp
+++ b/src/gpu/ResourceKey.cpp
@@ -7,6 +7,8 @@
 
 #include "src/gpu/ResourceKey.h"
 
+#include "src/core/SkRecordReplay.h"
+
 #include "src/core/SkChecksum.h"
 
 #include <atomic>
@@ -28,6 +30,7 @@ UniqueKey::Domain UniqueKey::GenerateDomain() {
     static std::atomic<int32_t> nextDomain{ResourceKey::kInvalidDomain + 1};
 
     int32_t domain = nextDomain.fetch_add(1, std::memory_order_relaxed);
+    SkRecordReplayAssert("[RUN-593-1969] UniqueKey::GenerateDomain %d", domain);
     if (domain > SkTo<int32_t>(UINT16_MAX)) {
         SK_ABORT("Too many skgpu::UniqueKey Domains");
     }

--- a/src/gpu/ganesh/ClipStack.cpp
+++ b/src/gpu/ganesh/ClipStack.cpp
@@ -240,6 +240,7 @@ uint32_t next_gen_id() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id < kFirstUnreservedGenID);
+    SkRecordReplayAssert("[RUN-593-1969] ClipStack/next_gen_id %u", id);
     return id;
 }
 

--- a/src/gpu/ganesh/GrContextThreadSafeProxy.cpp
+++ b/src/gpu/ganesh/GrContextThreadSafeProxy.cpp
@@ -26,6 +26,7 @@ static uint32_t next_id() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidGenID);
+    SkRecordReplayAssert("[RUN-593-1969] GrContextThreadSafeProxy/next_id %d", id);
     return id;
 }
 

--- a/src/gpu/ganesh/GrDirectContext.cpp
+++ b/src/gpu/ganesh/GrDirectContext.cpp
@@ -78,6 +78,7 @@ GrDirectContext::DirectContextID GrDirectContext::DirectContextID::Next() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidUniqueID);
+    SkRecordReplayAssert("[RUN-593-1969] GrDirectContext::DirectContextID::Next %u", id);
     return DirectContextID(id);
 }
 

--- a/src/gpu/ganesh/GrGpuResource.cpp
+++ b/src/gpu/ganesh/GrGpuResource.cpp
@@ -213,6 +213,7 @@ uint32_t GrGpuResource::CreateUniqueID() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidUniqueID);
+    SkRecordReplayAssert("[RUN-593-1969] GrGpuResource::CreateUniqueID %u", id);
     return id;
 }
 

--- a/src/gpu/ganesh/GrMemoryPool.cpp
+++ b/src/gpu/ganesh/GrMemoryPool.cpp
@@ -14,6 +14,8 @@
 #include <cstring>
 #include <new>
 
+#include "src/core/SkRecordReplay.h"
+
 #ifdef SK_DEBUG
     #include <atomic>
 #endif
@@ -89,6 +91,8 @@ void* GrMemoryPool::allocate(size_t size) {
         static std::atomic<int> nextID{1};
         return nextID.fetch_add(1, std::memory_order_relaxed);
     }();
+
+    SkRecordReplayAssert("[RUN-593-1969] GrMemoryPool::allocate fID=%d", header->fID);
 
     // You can set a breakpoint here when a leaked ID is allocated to see the stack frame.
     fDebug->fAllocatedIDs.add(header->fID);

--- a/src/gpu/ganesh/GrRenderTask.cpp
+++ b/src/gpu/ganesh/GrRenderTask.cpp
@@ -28,6 +28,7 @@ uint32_t GrRenderTask::CreateUniqueID() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidUniqueID);
+    SkRecordReplayAssert("[RUN-593-1969] GrRenderTask::CreateUniqueID %u", id);
     return id;
 }
 

--- a/src/gpu/ganesh/GrResourceAllocator.cpp
+++ b/src/gpu/ganesh/GrResourceAllocator.cpp
@@ -33,6 +33,7 @@ uint32_t GrResourceAllocator::Interval::CreateUniqueID() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidUniqueID);
+    SkRecordReplayAssert("[RUN-593-1969] GrResourceAllocator::Interval::CreateUniqueID %u", id);
     return id;
 }
 
@@ -42,6 +43,7 @@ uint32_t GrResourceAllocator::Register::CreateUniqueID() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidUniqueID);
+    SkRecordReplayAssert("[RUN-593-1969] GrResourceAllocator::Register::CreateUniqueID %u", id);
     return id;
 }
 #endif

--- a/src/gpu/graphite/GraphiteResourceKey.cpp
+++ b/src/gpu/graphite/GraphiteResourceKey.cpp
@@ -7,12 +7,15 @@
 
 #include "src/gpu/graphite/GraphiteResourceKey.h"
 
+#include "src/core/SkRecordReplay.h"
+
 namespace skgpu::graphite {
 
 ResourceType GraphiteResourceKey::GenerateResourceType() {
     static std::atomic<int32_t> nextType{ResourceKey::kInvalidDomain + 1};
 
     int32_t type = nextType.fetch_add(1, std::memory_order_relaxed);
+    SkRecordReplayAssert("[RUN-593-1969] GraphiteResourceKey::GenerateResourceType %d", type);
     if (type > SkTo<int32_t>(UINT16_MAX)) {
         SK_ABORT("Too many Graphite Resource Types");
     }

--- a/src/gpu/graphite/Recorder.cpp
+++ b/src/gpu/graphite/Recorder.cpp
@@ -113,6 +113,7 @@ uint32_t next_id() {
     do {
         id = nextID.fetch_add(1, std::memory_order_relaxed);
     } while (id == SK_InvalidGenID);
+    SkRecordReplayAssert("[RUN-593-1969] graphite/Recorder/next_id %d", id);
     return id;
 }
 

--- a/src/gpu/graphite/Renderer.cpp
+++ b/src/gpu/graphite/Renderer.cpp
@@ -7,6 +7,8 @@
 
 #include "src/gpu/graphite/Renderer.h"
 
+#include "src/core/SkRecordReplay.h"
+
 #include "src/gpu/graphite/DrawParams.h"
 #include "src/gpu/graphite/UniformManager.h"
 

--- a/src/image/SkSurface.cpp
+++ b/src/image/SkSurface.cpp
@@ -24,6 +24,8 @@
 #include "src/core/SkSurfacePriv.h"
 #include "src/image/SkSurface_Base.h"
 
+#include "src/core/SkRecordReplay.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <utility>
@@ -71,6 +73,7 @@ SkSurface::SkSurface(const SkImageInfo& info, const SkSurfaceProps* props)
 uint32_t SkSurface::generationID() {
     if (0 == fGenerationID) {
         fGenerationID = asSB(this)->newGenerationID();
+        SkRecordReplayAssert("[RUN-593-1969] SkSurface::generationID %u", fGenerationID);
     }
     return fGenerationID;
 }

--- a/src/ports/SkFontConfigInterface_direct.cpp
+++ b/src/ports/SkFontConfigInterface_direct.cpp
@@ -582,8 +582,9 @@ FcPattern* SkFontConfigInterfaceDirect::MatchFont(FcFontSet* font_set,
       if (acceptable_substitute)
         break;
     }
-    if (!acceptable_substitute)
+    if (!acceptable_substitute) {
       return nullptr;
+    }
   }
 
   return match;

--- a/src/ports/SkFontHost_FreeType.cpp
+++ b/src/ports/SkFontHost_FreeType.cpp
@@ -34,6 +34,7 @@
 #include "src/core/SkGlyph.h"
 #include "src/core/SkMask.h"
 #include "src/core/SkMaskGamma.h"
+#include "src/core/SkRecordReplay.h"
 #include "src/core/SkScalerContext.h"
 #include "src/ports/SkFontHost_FreeType_common.h"
 #include "src/ports/SkFontScanner_FreeType_priv.h"
@@ -218,7 +219,7 @@ private:
 };
 
 static SkMutex& f_t_mutex() {
-    static SkMutex& mutex = *(new SkMutex);
+    static SkMutex& mutex = *(new SkMutex("f_t_mutex"));
     return mutex;
 }
 
@@ -636,6 +637,9 @@ std::unique_ptr<SkAdvancedTypefaceMetrics> SkTypeface_FreeType::onGetAdvancedMet
                os2Table->version != 0xFFFF &&
                os2Table->version >= 2)
     {
+    // https://linear.app/replay/issue/RUN-845
+    SkRecordReplayAssert("SkTypeface_FreeType::onCreateScalerContext");
+
         info->fCapHeight = os2Table->sCapHeight;
     }
     info->fBBox = SkIRect::MakeLTRB(face->bbox.xMin, face->bbox.yMax,

--- a/src/ports/SkFontMgr_FontConfigInterface.cpp
+++ b/src/ports/SkFontMgr_FontConfigInterface.cpp
@@ -152,6 +152,7 @@ class SkFontMgr_FCI : public SkFontMgr {
 public:
     SkFontMgr_FCI(sk_sp<SkFontConfigInterface> fci, std::unique_ptr<SkFontScanner> scanner)
         : fFCI(std::move(fci))
+        , fMutex("SkFontMgr_FCI")
         , fScanner(std::move(scanner))
         , fCache(kMaxSize)
     {
@@ -179,6 +180,14 @@ protected:
                                          const SkFontStyle& requestedStyle) const override
     {
         SkAutoMutexExclusive ama(fMutex);
+
+        // If we've run out of recording data, then following this chain of logic will lead to
+        // hangs, as we await conditional vars on epoll waiters that don't actually exist, held
+        // by threads that are dead (waiting forever.)  Luckily, it seems we can just early out 
+        // and have Chromium use some defaults for us.
+        if (SkRecordReplayHasDivergedFromRecording()) {
+            return nullptr;
+        }
 
         // Check if this request is already in the request cache.
         using Request = SkFontRequestCache::Request;

--- a/src/ports/SkFontMgr_win_dw.cpp
+++ b/src/ports/SkFontMgr_win_dw.cpp
@@ -31,6 +31,8 @@
 #include <dwrite_2.h>
 #include <dwrite_3.h>
 
+#include "src/core/SkRecordReplay.h"
+
 using namespace skia_private;
 
 namespace {
@@ -108,7 +110,10 @@ public:
         , fFontCollection(SkRefComPtr(fontCollection))
         , fLocaleName(localeNameLength)
         , fDefaultFamilyName(defaultFamilyNameLength)
+        , fTFCacheMutex("SkFontMgr_DirectWrite")
     {
+    SkRecordReplayAssert("[RUN-2058] StreamFontFileLoader::CreateStreamFromKey");
+
         memcpy(fLocaleName.get(), localeName, localeNameLength * sizeof(WCHAR));
         memcpy(fDefaultFamilyName.get(), defaultFamilyName, defaultFamilyNameLength*sizeof(WCHAR));
     }
@@ -203,6 +208,8 @@ struct ProtoDWriteTypeface {
 };
 
 static bool FindByDWriteFont(SkTypeface* cached, void* ctx) {
+    SkRecordReplayAssert("[RUN-2612-2639] FindByDWriteFont %u", cached->uniqueID());
+
     DWriteFontTypeface* cshFace = reinterpret_cast<DWriteFontTypeface*>(cached);
     ProtoDWriteTypeface* ctxFace = reinterpret_cast<ProtoDWriteTypeface*>(ctx);
 
@@ -371,6 +378,9 @@ sk_sp<SkFontStyleSet> SkFontMgr_DirectWrite::onMatchFamily(const char familyName
     BOOL exists;
     HRNM(fFontCollection->FindFamilyName(dwFamilyName.get(), &index, &exists),
             "Failed while finding family by name.");
+
+    SkRecordReplayAssert("[RUN-2116] SkFontMgr_DirectWrite::onMatchFamily #2");
+
     if (!exists) {
         return nullptr;
     }

--- a/src/ports/SkScalerContext_mac_ct.cpp
+++ b/src/ports/SkScalerContext_mac_ct.cpp
@@ -52,6 +52,8 @@
 
 #include <algorithm>
 
+#include "src/core/SkRecordReplay.h"
+
 class SkDescriptor;
 
 
@@ -139,6 +141,15 @@ SkScalerContext_Mac::SkScalerContext_Mac(SkTypeface_Mac& typeface,
         fInvTransform = CGAffineTransformInvert(fTransform);
     } else {
         fInvTransform = fTransform;
+    }
+
+    if (SkRecordReplayAreEventsUnavailable("divergent-update")) {
+        // Short-circuit font creation because it requires a lot of
+        // bindings that we do not yet support.
+        // NOTE: All seconday arguments are currently ignored.
+        fCTFont.reset(CTFontCreateCopyWithAttributes(ctFont, 0, nullptr, nullptr));
+        fCGFont.reset(CTFontCopyGraphicsFont(ctFont, nullptr));
+        return;
     }
 
     // The transform contains everything except the requested text size.

--- a/src/ports/SkScalerContext_win_dw.cpp
+++ b/src/ports/SkScalerContext_win_dw.cpp
@@ -50,6 +50,8 @@
 #include <dwrite_1.h>
 #include <dwrite_3.h>
 
+#include "src/core/SkRecordReplay.h"
+
 namespace {
 static inline const constexpr bool kSkShowTextBlitCoverage = false;
 
@@ -398,6 +400,8 @@ SkScalerContext_DW::SkScalerContext_DW(DWriteFontTypeface& typefaceRef,
         SkMask::kA8_Format == fRec.fMaskFormat &&
         !(fRec.fFlags & SkScalerContext::kGenA8FromLCD_Flag))
     {
+    SkRecordReplayAssert("[RUN-2058] SkScalerContext_DW::getBoundingBox");
+
         // DWRITE_TEXTURE_ALIASED_1x1 is now misnamed, it must also be used with grayscale.
         fTextureType = DWRITE_TEXTURE_ALIASED_1x1;
         fAntiAliasMode = DWRITE_TEXT_ANTIALIAS_MODE_GRAYSCALE;
@@ -1597,6 +1601,9 @@ bool SkScalerContext_DW::generateDWMetrics(const SkGlyph& glyph,
                  "Could not create glyph run analysis.");
         }
     }
+
+    SkRecordReplayAssert("[RUN-2058] SkScalerContext_DW::getBoundingBox #1");
+
     RECT bbox;
     {
         Shared l(maybe_dw_mutex(*typeface));

--- a/src/ports/SkTypeface_mac_ct.cpp
+++ b/src/ports/SkTypeface_mac_ct.cpp
@@ -168,7 +168,7 @@ static bool find_by_CTFontRef(SkTypeface* cached, void* context) {
 sk_sp<SkTypeface> SkTypeface_Mac::Make(SkUniqueCFRef<CTFontRef> font,
                                        OpszVariation opszVariation,
                                        std::unique_ptr<SkStreamAsset> providedData) {
-    static SkMutex gTFCacheMutex;
+    static SkMutex gTFCacheMutex("SkTypeface_Mac::Make");
     static SkTypefaceCache gTFCache;
 
     SkASSERT(font);

--- a/src/ports/SkTypeface_win_dw.cpp
+++ b/src/ports/SkTypeface_win_dw.cpp
@@ -34,6 +34,8 @@
 #include "src/utils/win/SkDWrite.h"
 #include "src/utils/win/SkDWriteFontFileStream.h"
 
+#include "src/core/SkRecordReplay.h"
+
 using namespace skia_private;
 
 SkFontStyle DWriteFontTypeface::GetStyle(IDWriteFont* font, IDWriteFontFace* fontFace) {
@@ -441,6 +443,10 @@ SkTypeface::LocalizedStrings* DWriteFontTypeface::onCreateFamilyNameIterator() c
 }
 
 bool DWriteFontTypeface::onGlyphMaskNeedsCurrentColor() const {
+    if (SkRecordReplayAreEventsDisallowed("DWriteFontTypeface::onGlyphMaskNeedsCurrentColor")) {
+        // RUN-2619: We cannot read Windows fonts when replaying.
+        return false;
+    }
     return fDWriteFontFace2 && fDWriteFontFace2->GetColorPaletteCount() > 0;
 }
 
@@ -689,6 +695,8 @@ sk_sp<SkTypeface> DWriteFontTypeface::onMakeClone(const SkFontArguments& args) c
 }
 
 std::unique_ptr<SkStreamAsset> DWriteFontTypeface::onOpenStream(int* ttcIndex) const {
+    SkRecordReplayAssert("[RUN-2058] DWriteFontTypeface::onOpenStream");
+
     *ttcIndex = fDWriteFontFace->GetIndex();
 
     UINT32 numFiles = 0;

--- a/src/shaders/SkPictureShader.cpp
+++ b/src/shaders/SkPictureShader.cpp
@@ -281,6 +281,19 @@ sk_sp<SkShader> SkPictureShader::rasterShader(const SkMatrix& totalM,
         }
 
         SkResourceCache::Add(new ImageFromPictureRec(key, image));
+
+        if (SkRecordReplayIsRecordingOrReplaying()) {
+            // Track SkPicture cache size (so we get a general idea of memory impact)
+            SkRecordReplayPrint(
+                    "[RUN-593-1863] SkPictureShader::rasterShader - cache SkPicture %u: %d x %d x "
+                    "%d -> %zu",
+                    fPicture->uniqueID(),
+                    info.imageInfo.width(),
+                    info.imageInfo.height(),
+                    info.imageInfo.bytesPerPixel(),
+                    info.imageInfo.computeByteSize(info.imageInfo.minRowBytes()));
+        }
+
         SkPicturePriv::AddedToCache(fPicture.get());
     }
     // Scale the image to the original picture size.

--- a/src/sksl/SkSLPool.cpp
+++ b/src/sksl/SkSLPool.cpp
@@ -13,14 +13,40 @@
 
 namespace SkSL {
 
+#ifdef SK_BUILD_FOR_WIN
+
 static thread_local MemoryPool* sMemPool = nullptr;
 
+static MemoryPool*& memory_pool_location() {
+  return sMemPool;
+}
+
+#else // !SK_BUILD_FOR_WIN
+
+static MemoryPool*& memory_pool_location() {
+  static pthread_key_t key;
+  if (!key) {
+    int rv = pthread_key_create(&key, nullptr);
+    SkASSERT_RELEASE(rv == 0);
+    SkASSERT_RELEASE(key);
+  }
+
+  MemoryPool** v = (MemoryPool**)pthread_getspecific(key);
+  if (!v) {
+    v = new MemoryPool*(nullptr);
+    pthread_setspecific(key, v);
+  }
+  return *v;
+}
+
+#endif // !SK_BUILD_FOR_WIN
+
 static MemoryPool* get_thread_local_memory_pool() {
-    return sMemPool;
+    return memory_pool_location();
 }
 
 static void set_thread_local_memory_pool(MemoryPool* memPool) {
-    sMemPool = memPool;
+    memory_pool_location() = memPool;
 }
 
 Pool::Pool() = default;


### PR DESCRIPTION
## WIP: Re-apply Replay skia instrumentation onto M151 skia

`replayio/chromium-skia` forked at `3a990bac`. This re-applies the Replay determinism
instrumentation onto M151's skia (base `ae2e3d13`). Companion to replayio/chromium#1358.

### Landed (3 commits)
- 2 new files: `src/core/SkRecordReplay.{cpp,h}`
- 28 cleanly 3-way-merged hooks + 16 best-effort anchor-applied (NEEDS REVIEW)
- Determinism hooks across caches, mutex/semaphore, cpu, fonts, gpu resource keys.

### Remains
- 3 conflict files + 5 gone files (moved/removed in newer skia) → manual port.

**Base is `skia-m151-base`** (pinned M151 skia `ae2e3d13`), so the diff is exactly the replay changes.
NEEDS REVIEW hooks were auto-placed; verify at build/replay time.
